### PR TITLE
Added handler for extremote RequestiPodName

### DIFF
--- a/lingo-extremote/extremote.go
+++ b/lingo-extremote/extremote.go
@@ -32,6 +32,8 @@ var Lingos struct {
 	RetArtworkFormats                          `id:"0x000F"`
 	GetTrackArtworkData                        `id:"0x0010"`
 	RetTrackArtworkData                        `id:"0x0011"`
+	RequestiPodName                            `id:"0x0014"`
+	ReturniPodName                             `id:"0x0015"`
 	ResetDBSelection                           `id:"0x0016"`
 	SelectDBRecord                             `id:"0x0017"`
 	GetNumberCategorizedDBRecords              `id:"0x0018"`
@@ -249,6 +251,13 @@ type RetTrackArtworkData struct {
 	BottomRightY uint16
 	RowSize      uint32
 	Data         []byte
+}
+
+type RequestiPodName struct {
+}
+
+type ReturniPodName struct {
+	Name []byte
 }
 
 //ack

--- a/lingo-extremote/handler.go
+++ b/lingo-extremote/handler.go
@@ -74,6 +74,8 @@ func HandleExtRemote(req *ipod.Command, tr ipod.CommandWriter, dev DeviceExtRemo
 			Status: ACKStatusFailed,
 			CmdID:  req.ID.CmdID(),
 		})
+	case *RequestiPodName:
+		ipod.Respond(req, tr, &ReturniPodName{Name:ipod.StringToBytes("iPod")})
 	case *ResetDBSelection:
 		ipod.Respond(req, tr, ackSuccess(req))
 	case *SelectDBRecord:


### PR DESCRIPTION
RequestiPodName in extremote is deprecated in newer specifications but it's required on some older devices to recognize the iPod