### PR TITLE
Add deprecated RequestiPodName command

### DIFF
--- a/lingo-extremote/extremote.go
+++ b/lingo-extremote/extremote.go
@@ -30,6 +30,8 @@ var Lingos struct {
 	RetArtworkFormats                          `id:"0x000F"`
 	GetTrackArtworkData                        `id:"0x0010"`
 	RetTrackArtworkData                        `id:"0x0011"`
+	RequestiPodName                            `id:"0x0014"`
+	ReturniPodName                             `id:"0x0015"`
 	ResetDBSelection                           `id:"0x0016"`
 	SelectDBRecord                             `id:"0x0017"`
 	GetNumberCategorizedDBRecords              `id:"0x0018"`
@@ -249,7 +251,23 @@ type RetTrackArtworkData struct {
 	Data         []byte
 }
 
-//ack
+type RequestiPodName struct{}
+
+type ReturniPodName struct {
+	Name []byte
+}
+
+func (s ReturniPodName) MarshalBinary() ([]byte, error) {
+	return s.Name, nil
+}
+
+func (s *ReturniPodName) UnmarshalBinary(data []byte) error {
+	s.Name = make([]byte, len(data))
+	copy(s.Name, data)
+	return nil
+}
+
+// ack
 type ResetDBSelection struct {
 }
 

--- a/lingo-extremote/handler.go
+++ b/lingo-extremote/handler.go
@@ -75,7 +75,7 @@ func HandleExtRemote(req *ipod.Command, tr ipod.CommandWriter, dev DeviceExtRemo
 			CmdID:  req.ID.CmdID(),
 		})
 	case *RequestiPodName:
-		ipod.Respond(req, tr, &ReturniPodName{Name: ipod.StringToBytes("iPod Joey")})
+		ipod.Respond(req, tr, &ReturniPodName{Name: ipod.StringToBytes("iPod")})
 	case *ResetDBSelection:
 		ipod.Respond(req, tr, ackSuccess(req))
 	case *SelectDBRecord:

--- a/lingo-extremote/handler.go
+++ b/lingo-extremote/handler.go
@@ -74,6 +74,8 @@ func HandleExtRemote(req *ipod.Command, tr ipod.CommandWriter, dev DeviceExtRemo
 			Status: ACKStatusFailed,
 			CmdID:  req.ID.CmdID(),
 		})
+	case *RequestiPodName:
+		ipod.Respond(req, tr, &ReturniPodName{Name: ipod.StringToBytes("iPod Joey")})
 	case *ResetDBSelection:
 		ipod.Respond(req, tr, ackSuccess(req))
 	case *SelectDBRecord:


### PR DESCRIPTION
This is the deprecated version of the General lingo command: 0x07 (`RequestiPodName`). My car happens to use this command to get the name of the iPod rather than the new version.

<img width="410" height="150" alt="image" src="https://github.com/user-attachments/assets/98df672d-29d0-40bd-a5cd-19a486322907" />
<img width="396" height="548" alt="image" src="https://github.com/user-attachments/assets/526bd494-458c-4e62-a888-bf50d5833a96" />
